### PR TITLE
Add `skip-pkg-cache: true` to golangci-lint

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -42,6 +42,8 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: GolangCI Lint
         uses: golangci/golangci-lint-action@v3
+        with:
+          skip-pkg-cache: true
 
   test:
     name: Test ${{ matrix.go }}


### PR DESCRIPTION
Actions の golangci-lint で下記のようなエラーが出ているため設定を修正。

```
Error: /usr/bin/tar: ../../../go/pkg/mod/github.com/stripe/stripe-go/v73@v73.16.0/testhelpers/testclock/client.go: Cannot open: File exists
```